### PR TITLE
feat: component preset | 为插件添加组件预设选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ Install `antd` via an alias, such as `antd-v5`.
 
 Equivalent to `import { Button } from 'antd-v5'`.
 
+### Using manual preset
+
+```ts
+// vite.config.ts
+import AutoImport from 'unplugin-auto-import/vite'
+import AntdResolver, { allComponents } from 'unplugin-auto-import-antd'
+
+// Remove `Button` component
+const preset = [...allComponents].splice(allComponents.indexOf('Button'), 1)
+
+export default defineConfig({
+  plugins: [
+    AutoImport({
+      resolvers: [
+        AntdResolver({
+          preset: preset // `Button` component won't be auto imported
+        })
+      ]
+    })
+  ]
+})
+```
+
+By customizing the components preset, you can selectively auto-import the required components.
+
 ## License
 
 [MIT](/LICENSE) License &copy; 2024 [Bruce Song](https://github.com/recallwei)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,6 +121,31 @@ export default defineConfig({
 
 等价于 `import { Button } from 'antd-v5'`
 
+### 组件预设
+
+```ts
+// vite.config.ts
+import AutoImport from 'unplugin-auto-import/vite'
+import AntdResolver, { allComponents } from 'unplugin-auto-import-antd'
+
+// Remove `Button` component
+const preset = [...allComponents].splice(allComponents.indexOf('Button'), 1)
+
+export default defineConfig({
+  plugins: [
+    AutoImport({
+      resolvers: [
+        AntdResolver({
+          preset: preset // `Button` component won't be auto imported
+        })
+      ]
+    })
+  ]
+})
+```
+
+通过自定义组件预设，可以选择性地自动导入需要的组件。
+
 ## License
 
 [MIT](/LICENSE) License &copy; 2024 [Bruce Song](https://github.com/recallwei)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { antdResolver } from './resolver'
 
+export { antdBuiltInComponents as allComponents } from './preset'
 export default antdResolver

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,17 +1,17 @@
 import type { Resolver } from 'unplugin-auto-import/types'
 
-import { antdBuiltInComponents } from './preset'
 import type { AntdResolverOptions } from './types'
+import { antdBuiltInComponents } from './preset'
 import { getAntdComponentsMap } from './utils'
 
-export const antdResolver = (options: AntdResolverOptions = {}): Resolver => {
-  const { prefix, packageName: from = 'antd' } = options
-  const antdComponentsMap = getAntdComponentsMap(prefix)
+export function antdResolver(options: AntdResolverOptions = {}): Resolver {
+  const { prefix, packageName: from = 'antd', preset = antdBuiltInComponents } = options
+  const antdComponentsMap = getAntdComponentsMap(prefix, preset)
   return {
     type: 'component',
     resolve: (originName: string) => {
       if (!prefix) {
-        if (antdBuiltInComponents.includes(originName)) {
+        if (preset.includes(originName)) {
           return {
             from,
             name: originName

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,4 +9,8 @@ export interface AntdResolverOptions {
    * @default antd
    */
   packageName?: string
+  /**
+   * 要导入的组件，不指定则默认导入全部
+   */
+  preset?: string[]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { antdBuiltInComponents } from './preset'
 
 // 处理特殊的组件名（非大驼峰）
-export const getComponentName = (name: string) => {
+export function getComponentName(name: string) {
   if (name === 'theme') {
     return 'Theme'
   }
@@ -15,8 +15,10 @@ export const getComponentName = (name: string) => {
 }
 
 // 获取添加前缀后的组件名映射
-export const getAntdComponentsMap = (prefix?: string): Map<string, string> =>
-  antdBuiltInComponents.reduce(
+export function getAntdComponentsMap(prefix?: string, preset?: string[]): Map<string, string> {
+  const components = preset ?? [...antdBuiltInComponents]
+  return components.reduce(
     (map, name) => map.set(`${prefix ?? ''}${getComponentName(name)}`, name),
     new Map()
   )
+}


### PR DESCRIPTION
###  问题描述
在尝试导入Splitter组件时，发现无法导入。
经过排查后发现`src/preset.ts`的`antdBuiltInComponents`缺少Splitter。
### 解决方案
为Plugin的Options添加新的参数`preset`，手动设置preset。
```ts
// vite.config.ts
import AntdResolver, { allComponents } from "unplugin-auto-import-antd";

export default {
  ...
  plugins:  [
    AutoImport({
      resolvers: [
        AntdResolver({
            preset: [...allComponents, "Splitter"],
        }),
      ]
    })
  ]
}

```